### PR TITLE
Changing the hash-bang to use env so node doesn't have to be installe…

### DIFF
--- a/a0dump.js
+++ b/a0dump.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#! /usr/bin/env node
 
 const request = require('request');
 const fs = require('fs');
@@ -135,3 +135,4 @@ authenticate(config)
 	winston.error(e);
 	process.exit(1);
 });
+


### PR DESCRIPTION
…d at /usr/bin

Need to change the hash-bang or this won't work on many systems that don't have node installed at /usr/bin/node.